### PR TITLE
techpack: audio: Remove build timestamp injection

### DIFF
--- a/asoc/Kbuild
+++ b/asoc/Kbuild
@@ -245,6 +245,3 @@ machine_dlkm-y := $(MACHINE_OBJS)
 
 obj-$(CONFIG_SND_SOC_CPE) += cpe_lsm_dlkm.o
 cpe_lsm_dlkm-y := $(CPE_LSM_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/asoc/codecs/Kbuild
+++ b/asoc/codecs/Kbuild
@@ -254,6 +254,3 @@ hdmi_dlkm-y := $(HDMICODEC_OBJS)
 
 obj-$(CONFIG_SND_SOC_CS35L36) += cs35l36_dlkm.o
 cs35l36_dlkm-y := $(CS35L36_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/asoc/codecs/aqt1000/Kbuild
+++ b/asoc/codecs/aqt1000/Kbuild
@@ -119,6 +119,3 @@ endif
 # Module information used by KBuild framework
 obj-$(CONFIG_SND_SOC_AQT1000) += aqt1000_cdc_dlkm.o
 aqt1000_cdc_dlkm-y := $(AQT1000_CDC_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/asoc/codecs/bolero/Kbuild
+++ b/asoc/codecs/bolero/Kbuild
@@ -143,6 +143,3 @@ tx_macro_dlkm-y := $(TX_OBJS)
 
 obj-$(CONFIG_RX_MACRO) += rx_macro_dlkm.o
 rx_macro_dlkm-y := $(RX_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/asoc/codecs/csra66x0/Kbuild
+++ b/asoc/codecs/csra66x0/Kbuild
@@ -104,6 +104,3 @@ endif
 # Module information used by KBuild framework
 obj-$(CONFIG_SND_SOC_CSRA66X0) += csra66x0_dlkm.o
 csra66x0_dlkm-y := $(CSRA66X0_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/asoc/codecs/ep92/Kbuild
+++ b/asoc/codecs/ep92/Kbuild
@@ -105,6 +105,3 @@ endif
 # Module information used by KBuild framework
 obj-$(CONFIG_SND_SOC_EP92) += ep92_dlkm.o
 ep92_dlkm-y := $(EP92_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/asoc/codecs/msm_sdw/Kbuild
+++ b/asoc/codecs/msm_sdw/Kbuild
@@ -119,6 +119,3 @@ endif
 # Module information used by KBuild framework
 obj-$(CONFIG_SND_SOC_MSM_SDW) += msm_sdw_dlkm.o
 msm_sdw_dlkm-y := $(MSM_SDW_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/asoc/codecs/sdm660_cdc/Kbuild
+++ b/asoc/codecs/sdm660_cdc/Kbuild
@@ -125,6 +125,3 @@ analog_cdc_dlkm-y := $(ANALOG_CDC_OBJS)
 
 obj-$(CONFIG_SND_SOC_DIGITAL_CDC) += digital_cdc_dlkm.o
 digital_cdc_dlkm-y := $(DIGITAL_CDC_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/asoc/codecs/wcd934x/Kbuild
+++ b/asoc/codecs/wcd934x/Kbuild
@@ -140,6 +140,3 @@ endif
 # Module information used by KBuild framework
 obj-$(CONFIG_SND_SOC_WCD934X) += wcd934x_dlkm.o
 wcd934x_dlkm-y := $(WCD934X_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/asoc/codecs/wcd9360/Kbuild
+++ b/asoc/codecs/wcd9360/Kbuild
@@ -109,6 +109,3 @@ endif
 # Module information used by KBuild framework
 obj-$(CONFIG_SND_SOC_WCD9360) += wcd9360_dlkm.o
 wcd9360_dlkm-y := $(WCD9360_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/asoc/codecs/wcd937x/Kbuild
+++ b/asoc/codecs/wcd937x/Kbuild
@@ -117,6 +117,3 @@ wcd937x_dlkm-y := $(WCD937X_OBJS)
 
 obj-$(CONFIG_SND_SOC_WCD937X_SLAVE) += wcd937x_slave_dlkm.o
 wcd937x_slave_dlkm-y := $(WCD937X_SLAVE_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/dsp/Kbuild
+++ b/dsp/Kbuild
@@ -218,6 +218,3 @@ q6_pdr_dlkm-y := $(QDSP6_PDR_OBJS)
 
 obj-$(CONFIG_MSM_QDSP6_NOTIFIER) += q6_notifier_dlkm.o
 q6_notifier_dlkm-y := $(QDSP6_NOTIFIER_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/dsp/codecs/Kbuild
+++ b/dsp/codecs/Kbuild
@@ -162,6 +162,3 @@ endif
 # Module information used by KBuild framework
 obj-$(CONFIG_MSM_QDSP6V2_CODECS) += native_dlkm.o
 native_dlkm-y := $(NATIVE_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/ipc/Kbuild
+++ b/ipc/Kbuild
@@ -162,6 +162,3 @@ apr_dlkm-y := $(APRV_GLINK)
 
 obj-$(CONFIG_WCD_DSP_GLINK) += wglink_dlkm.o
 wglink_dlkm-y := $(WDSP_GLINK)
-
-# inject some build related information
-CDEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"

--- a/soc/Kbuild
+++ b/soc/Kbuild
@@ -173,6 +173,3 @@ snd_event_dlkm-y := $(SND_EVENT_OBJS)
 obj-$(CONFIG_SOUNDWIRE_WCD_CTRL) += swr_ctrl_dlkm.o
 obj-$(CONFIG_SOUNDWIRE_MSTR_CTRL) += swr_ctrl_dlkm.o
 swr_ctrl_dlkm-y := $(SWR_CTRL_OBJS)
-
-# inject some build related information
-DEFINES += -DBUILD_TIMESTAMP=\"$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')\"


### PR DESCRIPTION
This causes parts of the audio module to be rebuilt during every
incremental build, even if there are no changes:

  CC      techpack/audio/ipc/apr.o - due to command line change
  CC      techpack/audio/ipc/apr_v2.o - due to command line change
  CC      techpack/audio/ipc/apr_tal_rpmsg.o - due to command line change
  CC      techpack/audio/ipc/wcd-dsp-glink.o - due to command line change

We're only experiencing this issue in techpack/audio/ipc at the moment,
but kill the timestamp injection in all the audio components to
eliminate the possibility of encountering this issue again in the
future. This is harmless since the injected BUILD_TIMESTAMP macro is
never used.

Signed-off-by: Danny Lin <danny@kdrag0n.dev>
Signed-off-by: anupritaisno1 <www.anuprita804@gmail.com>